### PR TITLE
Explicitly tell Postgres to not use auth by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: postgres
     volumes:
       - postgres:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
 
   redis:
     image: redis


### PR DESCRIPTION
Per https://www.postgresql.org/docs/current/auth-trust.html, otherwise the container won't boot asking for a password.